### PR TITLE
Mark all files as linguist-detectable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* linguist-detectable
+flake.lock linguist-generated


### PR DESCRIPTION
Also mark flake.lock files as linguist-generated to exclude them from stats.